### PR TITLE
Update schema.sql (again)

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -38,6 +38,5 @@ CREATE TABLE IF NOT EXISTS `device` (
     `uuid` varchar(128) PRIMARY KEY UNIQUE NOT NULL,
     `config` varchar(64) DEFAULT NULL,
     `last_seen` int DEFAULT NULL,
-    UNIQUE KEY `uk_iconfig_name` (`config`),
     CONSTRAINT `fk_config_name` FOREIGN KEY (`config`) REFERENCES `config` (`name`) ON DELETE SET NULL ON UPDATE CASCADE
 );


### PR DESCRIPTION
Removed the "unique" line so configs can be reused on multiple devices. I got timed out in the webUI because I tried to reuse the same config. I think it's useful to reuse configs but let me know if this causes some issue I didn't see.