### PR TITLE
Fix schedules with only one selected device

### DIFF
--- a/src/models/schedule-manager.js
+++ b/src/models/schedule-manager.js
@@ -27,7 +27,7 @@ class ScheduleManager {
         schedules[name] = {
             name: name,
             config: config,
-            uuids: uuids,
+            uuids: Array.isArray(uuids) ? uuids : uuids.split(','),
             start_time: startTime === '00:00:00' ? '00:00:01' : startTime,
             end_time: endTime,
             timezone: parseInt(timezone),


### PR DESCRIPTION
When assigning only one device to the schedule the following error occurs when loading schedules:

```
You have triggered an unhandledRejection, you may have forgotten to catch a Promise rejection:
TypeError: (schedule.uuids || []).join is not a function
    at /home/pi/pogo-tools/DeviceConfigManager/src/routes/api.js:579:53
    at Array.forEach (<anonymous>)
```

We have to make sure that `schedule.uuids` is always an array