### PR TITLE
Exclude Devices From Reboots

### DIFF
--- a/migrations/14.sql
+++ b/migrations/14.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `devices` ADD COLUMN `exclude_reboots` tinyint DEFAULT 0;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -195,9 +195,10 @@ router.get('/devices', async (req, res) => {
                         <a href="/device/edit/${encodedUuid}" class="dropdown-item">Edit</a>
                         <a href="/device/logs/${encodedUuid}" class="dropdown-item">Logs</a>
                         <h6 class="dropdown-header">Actions</h6>
-                        <button type="button" class="dropdown-item" onclick='reboot("${config.listeners}", "${device.uuid}")'>Reboot Device</button>
+                        <button type="button" class="dropdown-item" onclick='reboot("${config.listeners}", "${device.uuid}", "${device.exclude_reboots}")'>Reboot Device</button>
                     </div>
                 </div>`;
+                device.exclude_reboots = device.exclude_reboots ? 'Yes' : 'No';
                 device.enabled = device.enabled ? 'Yes' : 'No';
                 const date = utils.convertTz(new Date());
                 const today = date.format('YYYY-M-D');
@@ -265,9 +266,10 @@ router.post('/device/new', async (req, res) => {
         data.config || null,
         null,
         data.clientip || null,
-        null,
+        8080,
         null,
         data.notes || null,
+        data.exclude_reboots === 'on',
         data.enabled === 'on'
     );
     if (result) {
@@ -283,6 +285,7 @@ router.post('/device/edit/:uuid', async (req, res) => {
         config,
         clientip,
         notes,
+        exclude_reboots,
         enabled
     } = req.body;
     let device = await Device.getByName(uuid);
@@ -290,6 +293,7 @@ router.post('/device/edit/:uuid', async (req, res) => {
         device.config = config || null;
         device.clientip = clientip || null;
         device.notes = notes || null;
+        device.excludeReboots = exclude_reboots === 'on';
         device.enabled = enabled === 'on';
         const result = await device.save();
         if (!result) {

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -42,7 +42,7 @@ router.get(['/', '/index'], async (req, res) => {
         data.devices_offline = devices.filter(x => x.last_seen < (Math.round(utils.convertTz(new Date()).format('x') / 1000) - delta));
         data.devices_offline.forEach((device) => {
             device.last_seen = utils.getDateTime(device.last_seen * 1000);
-            device.buttons = `<button type='button' class='btn btn-success' onclick='reboot("${config.listeners}", "${device.uuid}")'>Reboot</button>`; // TODO: Localize
+            device.buttons = `<button type='button' class='btn btn-success' onclick='reboot("${config.listeners}", "${device.uuid}", "${device.exclude_reboots}")'>Reboot</button>`; // TODO: Localize
             device.uuid = `<a href='/device/manage/${device.uuid}' target='_blank' class='text-light'>${device.uuid}</a>`;
         });
         data.devices_online_count = devices.filter(x => x.last_seen >= (Math.round(utils.convertTz(new Date()).format('x') / 1000) - delta)).length;
@@ -116,6 +116,7 @@ router.get('/device/edit/:uuid', async (req, res) => {
     data.clientip = device.clientip;
     data.webserver_port = device.webserverPort;
     data.notes = device.notes;
+    data.exclude_reboots = device.excludeReboots ? 'checked' : '';
     data.enabled = device.enabled ? 'checked' : '';
     res.render('device-edit', data);    
 });
@@ -146,6 +147,7 @@ router.get('/device/manage/:uuid', async (req, res) => {
             logger('dcm').error(`Failed to get IP address for device ${uuid}`);
         }
         data.webserver_port = device.webserverPort;
+        data.exclude_reboots = device.excludeReboots;
         const config = await Config.getByName(device.config);
         data.providers = providers;
         data.kevin_selected = config.provider === data.providers[1].name;

--- a/src/services/device-monitor.js
+++ b/src/services/device-monitor.js
@@ -28,7 +28,7 @@ const checkDevices = async () => {
     for (let i = 0; i < devices.length; i++) {
         const device = devices[i];
         const isOffline = device.last_seen > (Math.round(utils.convertTz(new Date()).format('x') / 1000) - delta) ? 0 : 1;
-        if (!isOffline || !device.enabled) {
+        if (!isOffline || !device.enabled || device.exclude_reboots) {
             continue;
         }
 

--- a/src/views/device-edit.mustache
+++ b/src/views/device-edit.mustache
@@ -37,6 +37,10 @@
                     <input type="text" class="form-control" name="notes" value="{{notes}}" placeholder="">
                 </div>
                 <div class="form-check">
+                    <input type="checkbox" class="form-check-input" name="exclude_reboots" {{exclude_reboots}}>
+                    <label class="form-check-label" for="exclude_reboots">{{Exclude From Reboots}}</label>
+                </div>
+                <div class="form-check">
                     <input type="checkbox" class="form-check-input" name="enabled" {{enabled}}>
                     <label class="form-check-label" for="enabled">{{Enabled}}</label>
                 </div>

--- a/src/views/device-manage.mustache
+++ b/src/views/device-manage.mustache
@@ -56,7 +56,7 @@
                     </tr>
                     <tr>
                         <th>{{Reboot Device}}</th>
-                        <th><button type='button' class='btn btn-success' onclick='reboot("{{{listeners}}}", "{{name}}")'>{{REBOOT}}</button></th>
+                        <th><button type='button' class='btn btn-success' onclick='reboot("{{{listeners}}}", "{{name}}", "{{exclude_reboots}}")'>{{REBOOT}}</button></th>
                         <th><div id='reboot'></div></th>
                     </tr>
                     <tr>

--- a/src/views/device-new.mustache
+++ b/src/views/device-new.mustache
@@ -29,6 +29,10 @@
                     <input type="text" class="form-control" name="notes" value="" placeholder="">
                 </div>
                 <div class="form-check">
+                    <input type="checkbox" class="form-check-input" name="exclude_reboots">
+                    <label class="form-check-label" for="exclude_reboots">{{Exclude From Reboots}}</label>
+                </div>
+                <div class="form-check">
                     <input type="checkbox" class="form-check-input" name="enabled" checked>
                     <label class="form-check-label" for="enabled">{{Enabled}}</label>
                 </div>

--- a/src/views/devices.mustache
+++ b/src/views/devices.mustache
@@ -70,6 +70,7 @@
                     <th class="all">{{Last Config}}</th>
                     <th class="min-desktop">{{Notes}}</th>
                     <th class="all">{{Game Restarts Today}}</th>
+                    <th class="min-desktop">{{Exclude From Reboots}}</th>
                     <th class="all">{{Enabled}}</th>
                     <th class="all" width="5%"></th>
                 </tr>
@@ -141,6 +142,7 @@
                 { "data": "last_seen" },
                 { "data": "notes" },
                 { "data": "game_restarts_today" },
+                { "data": "exclude_reboots" },
                 { "data": "enabled" },
                 { "data": "buttons" }
             ],

--- a/static/js/device.js
+++ b/static/js/device.js
@@ -1,4 +1,7 @@
-function reboot(listeners, uuid) {
+function reboot(listeners, uuid, excludeReboots) {
+    if (parseInt(excludeReboots) === 1) {
+        return;
+    }
     const listenersList = (listeners || '').split(',');
     console.log('Listeners:', listenersList);
     for (let i = 0; i < listenersList.length; i++) {

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -142,5 +142,6 @@
     "Max Reboot Count": "Max Reboot Count",
     "Timezone": "Timezone",
     "Clear Device IP Addresses": "Clear Device IP Addresses",
-    "Model": "Model"
+    "Model": "Model",
+    "Exclude From Reboots": "Exclude From Reboots"
 }

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -142,5 +142,6 @@
     "Max Reboot Count": "Max Reboot Count",
     "Timezone": "Timezone",
     "Clear Device IP Addresses": "Clear Device IP Addresses",
-    "Model": "Model"
+    "Model": "Model",
+    "Exclude From Reboots": "Exclude From Reboots"
 }

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -140,5 +140,6 @@
     "Max Reboot Count": "Max Reboot Count",
     "Timezone": "Timezone",
     "Clear Device IP Addresses": "Clear Device IP Addresses",
-    "Model": "Model"
+    "Model": "Model",
+    "Exclude From Reboots": "Exclude From Reboots"
 }


### PR DESCRIPTION
Fix #71 
Adds the option to exclude specific devices from reboot requests.

![image](https://user-images.githubusercontent.com/1327440/93656076-8a803200-f9dc-11ea-8f3a-34f3d8e11508.png)

![image](https://user-images.githubusercontent.com/1327440/93656079-91a74000-f9dc-11ea-958b-b03ca271bfc6.png)
