### PR TITLE
IP address auto-sync config option

### DIFF
--- a/src/config.example.json
+++ b/src/config.example.json
@@ -29,5 +29,6 @@
         "password": "pass123",
         "database": "dcm",
         "charset": "utf8mb4"
-    }
+    },
+    "autoSyncIP": true
 }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -417,8 +417,8 @@ router.post('/config', AuthTokenMiddleware, async (req, res) => {
     if (device) {
         // Device exists
         device.lastSeen = utils.convertTz(new Date()) / 1000;
-        // Only update client IP if it hasn't been set yet.
-        if (device.clientip === null || device.clientip !== clientip) {
+        // Only update client IP if it hasn't been set yet or if auto sync is enabled while IP doesn't match
+        if (device.clientip === null || (device.clientip !== clientip && config.autoSyncIP)) {
             device.clientip = clientip;
         }
         device.iosVersion = ios_version;


### PR DESCRIPTION
Closes: #88 

Adds config option to automatically update device IP address if `autoSyncIP` is enabled, otherwise IP will only be updated if `clientip` column is null.